### PR TITLE
Added jQuery CDN Link

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -22,6 +22,8 @@
         {{> footer}}
     </footer>
     {{ghost_foot}}
+    <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
+    <script src="//code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
     <script src="{{asset 'js/scripts.js'}}"></script>
 </body>
 </html>


### PR DESCRIPTION
bring the template back to life after `jquery` was removed from `ghost`.